### PR TITLE
fix app exposure on public IP

### DIFF
--- a/conf/motioneye.conf
+++ b/conf/motioneye.conf
@@ -15,7 +15,7 @@ log_level info
 
 # the IP address to listen on
 # (0.0.0.0 for all interfaces, 127.0.0.1 for localhost)
-listen 0.0.0.0
+listen 127.0.0.1
 
 # the TCP port to listen on
 port 8765


### PR DESCRIPTION
## Problem

- the motioneye installation can be exposed without the yunohost reverse proxy if binded on public IP

## Solution

- change 0.0.0.0 (all interfaces) to 127.0.0.1 (localhost) in the bind config

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)