### PR TITLE
Web Access Fix

### DIFF
--- a/conf/motioneye.conf
+++ b/conf/motioneye.conf
@@ -15,7 +15,7 @@ log_level info
 
 # the IP address to listen on
 # (0.0.0.0 for all interfaces, 127.0.0.1 for localhost)
-listen 127.0.0.1
+listen 0.0.0.0
 
 # the TCP port to listen on
 port __PORT__

--- a/scripts/install
+++ b/scripts/install
@@ -32,7 +32,7 @@ ynh_add_nginx_config
 # Create a dedicated systemd config
 ynh_add_systemd_config
 
-yunohost service add $app --description="Web frontend for the motion daemon" --log="/var/log/$app/$app.log"
+yunohost service add $app --description="Web frontend for the motion daemon" --log="/var/log/$app/$app.log" --needs_exposed_ports 8765
 
 # Use logrotate to manage application logfile(s)
 ynh_use_logrotate


### PR DESCRIPTION
## Problem
A fresh install of motionEye can result in the page being inaccessible. Port 8765 isn't opened by default, and motionEye's config only allows for access from localhost, though this does sound correct, it means that the page is inaccessible.

- *Description of why you made this PR*
After experimenting for a while I found this fix. If the app is accessed from elsewhere it's blocked until I allow listening for all interfaces, and _then_ opened port 8765

## Solution
Both port and listen need to be open in order to be accessed.

- *And how do you fix that problem*
I've changed the `listen 127.0.0.1` to `listen 0.0.0.0` in the motioneye.conf file, as well as added `--needs_exposed_ports 8765` to the install script.

## PR Status
- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
